### PR TITLE
Implement network plugins.

### DIFF
--- a/StackNetwork.xcodeproj/project.pbxproj
+++ b/StackNetwork.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		3A24D7C223C66F1D00EDC931 /* RetryBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A24D7C123C66F1D00EDC931 /* RetryBehavior.swift */; };
 		3A24D7C423C674C800EDC931 /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A24D7C323C674C800EDC931 /* Aliases.swift */; };
 		3A24D7C723C67C3200EDC931 /* MultiTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A24D7C623C67C3200EDC931 /* MultiTarget.swift */; };
+		3A2EBCDD23EDDB440051E223 /* PluginType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2EBCDC23EDDB440051E223 /* PluginType.swift */; };
 		3A61F49223AE1F4200A8E47C /* StackNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A61F48823AE1F4200A8E47C /* StackNetwork.framework */; };
 		3A61F49923AE1F4200A8E47C /* StackNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A61F48B23AE1F4200A8E47C /* StackNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A61F4A423AE277400A8E47C /* NetworkProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A61F4A323AE277400A8E47C /* NetworkProviderType.swift */; };
@@ -86,6 +87,7 @@
 		3A24D7C123C66F1D00EDC931 /* RetryBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryBehavior.swift; sourceTree = "<group>"; };
 		3A24D7C323C674C800EDC931 /* Aliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Aliases.swift; sourceTree = "<group>"; };
 		3A24D7C623C67C3200EDC931 /* MultiTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiTarget.swift; sourceTree = "<group>"; };
+		3A2EBCDC23EDDB440051E223 /* PluginType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginType.swift; sourceTree = "<group>"; };
 		3A61F48823AE1F4200A8E47C /* StackNetwork.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StackNetwork.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A61F48B23AE1F4200A8E47C /* StackNetwork.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StackNetwork.h; sourceTree = "<group>"; };
 		3A61F48C23AE1F4200A8E47C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				3A61F4B623AE2E7B00A8E47C /* Cancellable.swift */,
 				3A1C21A923C09BEC00D1FD66 /* Request.swift */,
 				3A24D7C323C674C800EDC931 /* Aliases.swift */,
+				3A2EBCDC23EDDB440051E223 /* PluginType.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -399,6 +402,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3A2EBCDD23EDDB440051E223 /* PluginType.swift in Sources */,
 				3A61F4AA23AE27E700A8E47C /* Task.swift in Sources */,
 				3A1C21AA23C09BEC00D1FD66 /* Request.swift in Sources */,
 				3A61F4BE23AE4A3A00A8E47C /* JSONEncoder+RequestEncoding.swift in Sources */,

--- a/StackNetwork/Source/Aliases.swift
+++ b/StackNetwork/Source/Aliases.swift
@@ -1,7 +1,4 @@
 //
-//  Aliases.swift
-//  StackNetwork
-//
 //  Created by Mai Mai on 1/8/20.
 //  Copyright © 2020 maimai. All rights reserved.
 //
@@ -13,7 +10,7 @@ import Foundation
 public typealias NetworkCompletion = (Result<Response, Error>) -> Void
 
 public typealias RequestAdapterClosure = (URLRequest) throws -> URLRequest
-public typealias RetryBehaviorClosure = (Request, Error) -> RetryBehavior
+public typealias RetryBehaviorClosure = (Retryable, Error) -> RetryBehavior
 public typealias StubBehaviorClosure<Target: TargetType> = (Target) -> StubBehavior
 
 // MARK: Misc

--- a/StackNetwork/Source/PluginType.swift
+++ b/StackNetwork/Source/PluginType.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Mai Mai on 2/7/20.
+//  Copyright © 2020 maimai. All rights reserved.
+//
+
+/// A Network Plugin receives callbacks to perform side effects wherever a request is sent or received.
+///
+/// For example, a plugin may be used to
+/// - log network requests
+/// - hide and show a network activity indicator
+public protocol PluginType {
+
+    /// Called immediately before a request is sent over the network (or stubbed).
+    func willSend(_ request: Requestable)
+
+    /// Called after a response has been received, but before the `NetworkProvider` has invoked its completion handler.
+    func didReceive(_ result: Result<Response, Error>, request: Requestable)
+}

--- a/StackNetwork/Source/Request.swift
+++ b/StackNetwork/Source/Request.swift
@@ -1,20 +1,24 @@
 //
-//  Request.swift
-//  StackNetwork
-//
 //  Created by Mai Mai on 1/4/20.
 //  Copyright © 2020 maimai. All rights reserved.
 //
 
 import Foundation
 
-/// Reifies a target represented by `Target` into a concrete `Request`.
-public final class Request {
+public protocol Requestable {
+    /// The `URLRequest` associated with this load.
+    var urlRequest: URLRequest { get }
+}
 
-    /// The internal `URLRequest` of the receiver.
+public protocol Retryable {
+    /// The number of retries.
+    var retryCount: Int { get }
+}
+
+/// Refies a target represented by `Target` into a concrete `Request`.
+public final class Request: Requestable, Retryable {
+
     public internal(set) var urlRequest: URLRequest
-
-    /// Number of times the `Request` has been retried.
     public internal(set) var retryCount: Int {
         get {
             lock.lock()

--- a/StackNetworkTests/NetworkIntegrationSpecs.swift
+++ b/StackNetworkTests/NetworkIntegrationSpecs.swift
@@ -118,6 +118,46 @@ class NetworkIntegrationSpecs: QuickSpec {
         }
 
         describe("A NetworkProvider instance") {
+
+            class TestNetworkPlugin: PluginType {
+                var request: Requestable?
+                var result: Result<Response, Error>?
+
+                func willSend(_ request: Requestable) {
+                    self.request = request
+                }
+
+                func didReceive(_ result: Result<Response, Error>, request: Requestable) {
+                    self.result = result
+                }
+            }
+
+            var plugin: TestNetworkPlugin!
+
+            beforeEach {
+                plugin = TestNetworkPlugin()
+                sut = NetworkProvider<GitHub>(plugins: [plugin])
+            }
+
+            it("will inform plugins before request is sent") {
+                waitUntil(timeout: 2) { done in
+                    _ = sut.request(.zen) { _ in
+                        expect(plugin.request?.urlRequest.url?.absoluteString) == "https://api.github.com/zen"
+                        done()
+                    }
+                }
+            }
+            it("will inform plugins when result is received") {
+                waitUntil(timeout: 2) { done in
+                    _ = sut.request(.zen) { _ in
+                        expect(plugin.result).toNot(beNil())
+                        done()
+                    }
+                }
+            }
+        }
+
+        describe("A NetworkProvider instance") {
             var requestCount = 0
 
             beforeEach {


### PR DESCRIPTION
- A network plugin will be notified when a request will be sent && when
a result has been received. It CANNOT modify a network request OR
network response.